### PR TITLE
Add reading calendar with book recommendations

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,7 @@ Remember, it's self-paced so feel free to take a break! ☕️
 
 &copy; 2025 GitHub &bull; [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct/code_of_conduct.md) &bull; [MIT License](https://gh.io/mit)
 
+
+## Demo
+
+A simple reading calendar with mood-based book recommendations is provided in the `reading_calendar` folder. Open `index.html` in a browser to try it.

--- a/reading_calendar/index.html
+++ b/reading_calendar/index.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>読書記録カレンダー</title>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <header>
+    <h1>📅 <span id="monthLabel"></span></h1>
+    <div class="month-switch">
+      <button id="prevMonth">← 前の月</button>
+      <button id="nextMonth">次の月 →</button>
+    </div>
+  </header>
+  <main>
+    <section class="calendar-page">
+      <div class="calendar-grid" id="calendar"></div>
+    </section>
+    <section class="bookmark-page" style="display:none;">
+      <h2>🔖 しおりページ</h2>
+      <div class="filter-buttons">
+        <button data-filter="all">すべて表示</button>
+        <button data-filter="読了">✅読了だけ</button>
+        <button data-filter="未読">⏳未読だけ</button>
+        <button data-filter="favorite">⭐お気に入りだけ</button>
+        <button data-filter="💘">💘感動だけ</button>
+        <button data-filter="😭">😭泣いただけ</button>
+        <button data-filter="💧">💧悲しいだけ</button>
+        <button data-filter="😲">😲驚いただけ</button>
+        <button data-filter="😴">😴眠いだけ</button>
+      </div>
+      <div id="bookmark-list"></div>
+    </section>
+    <section class="mypage-page" style="display:none;">
+      <h2>📊 スタンプ傾向</h2>
+      <canvas id="stampChart" width="400" height="300"></canvas>
+    </section>
+    <section class="recommend-page" style="display:none;">
+      <h2>📚 おすすめ本ジェネレータ</h2>
+      <textarea id="impression-text" placeholder="感想を入力してください"></textarea>
+      <button id="analyze-btn" class="submit-btn">分析しておすすめ表示</button>
+      <div id="book-card"></div>
+    </section>
+  </main>
+  <div class="modal" id="edit-modal">
+    <div class="modal-content">
+      <button class="close-btn" id="calendar-edit-close">✖️</button>
+      <h2 id="edit-date-title">📘 記録編集</h2>
+      <input type="text" id="calendar-edit-title" placeholder="書名" />
+      <input type="text" id="calendar-edit-author" placeholder="著者" />
+      <textarea id="calendar-edit-impression" placeholder="感想"></textarea>
+      <input type="text" id="calendar-edit-quote" placeholder="お気に入りの一文" />
+      <div class="status-select">
+        <label><input type="radio" name="status" value="読了"> ✅ 読了</label>
+        <label><input type="radio" name="status" value="未読"> ⏳ 未読</label>
+      </div>
+      <div class="favorite-select">
+        <label><input type="checkbox" id="favorite-check"> ⭐お気に入り登録</label>
+      </div>
+      <div id="calendar-edit-stamps">
+        <span class="stamp">💘</span>
+        <span class="stamp">😭</span>
+        <span class="stamp">💧</span>
+        <span class="stamp">😲</span>
+        <span class="stamp">😴</span>
+      </div>
+      <div class="form-buttons">
+        <button class="submit-btn" id="calendar-edit-save">保存</button>
+        <button class="delete-btn" id="calendar-edit-delete">削除</button>
+      </div>
+    </div>
+  </div>
+  <div class="nav">
+    <a href="#" data-target="calendar-page">📅 カレンダー</a>
+    <a href="#" data-target="bookmark-page">🔖 しおり</a>
+    <a href="#" data-target="mypage-page">📊 マイページ</a>
+    <a href="#" data-target="recommend-page">📚 おすすめ</a>
+  </div>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/reading_calendar/index.html
+++ b/reading_calendar/index.html
@@ -44,6 +44,19 @@
       <button id="analyze-btn" class="submit-btn">分析しておすすめ表示</button>
       <div id="book-card"></div>
     </section>
+    <section class="omikuji-page" style="display:none;">
+      <h2>🎲 今日の本みくじ</h2>
+      <p>いまの気分を選んでください:</p>
+      <div id="mood-buttons">
+        <button data-mood="癒し">癒し</button>
+        <button data-mood="冒険">冒険</button>
+        <button data-mood="恋愛">恋愛</button>
+        <button data-mood="ミステリー">ミステリー</button>
+        <button data-mood="ファンタジー">ファンタジー</button>
+      </div>
+      <p id="roulette-status"></p>
+      <div id="omikuji-card"></div>
+    </section>
   </main>
   <div class="modal" id="edit-modal">
     <div class="modal-content">
@@ -78,6 +91,7 @@
     <a href="#" data-target="bookmark-page">🔖 しおり</a>
     <a href="#" data-target="mypage-page">📊 マイページ</a>
     <a href="#" data-target="recommend-page">📚 おすすめ</a>
+    <a href="#" data-target="omikuji-page">🎲 みくじ</a>
   </div>
   <script src="script.js"></script>
 </body>

--- a/reading_calendar/script.js
+++ b/reading_calendar/script.js
@@ -180,3 +180,35 @@ document.getElementById('analyze-btn').addEventListener('click',async()=>{
         console.error(err);
     }
 });
+
+// --- book omikuji by mood ---
+const moodKeywords={
+    '癒し':'癒し 小説',
+    '冒険':'冒険 小説',
+    '恋愛':'恋愛 小説',
+    'ミステリー':'ミステリー 小説',
+    'ファンタジー':'ファンタジー 小説'
+};
+
+document.querySelectorAll('#mood-buttons button').forEach(btn=>{
+    btn.addEventListener('click',async()=>{
+        const mood=btn.getAttribute('data-mood');
+        const status=document.getElementById('roulette-status');
+        const card=document.getElementById('omikuji-card');
+        if(!status||!card) return;
+        status.textContent='📚 選書中...';
+        card.innerHTML='';
+        try{
+            const book=await fetchBookByKeyword(moodKeywords[mood]||'小説');
+            status.textContent='🎉 今日のおすすめはこちら！';
+            displayOmikujiCard(book);
+        }catch(err){
+            status.textContent='⚠️ 本が見つかりませんでした';
+        }
+    });
+});
+
+function displayOmikujiCard(book){
+    const html=`<div class="recommend-card"><h3>${book.title}</h3><p><strong>著者:</strong> ${book.authors}</p><p><strong>あらすじ:</strong> ${book.description}</p>${book.thumbnail?`<img src="${book.thumbnail}" alt="表紙">`:''}<br><a href="${book.infoLink}" target="_blank">📖 詳しく読む</a></div>`;
+    document.getElementById('omikuji-card').innerHTML=html;
+}

--- a/reading_calendar/script.js
+++ b/reading_calendar/script.js
@@ -1,0 +1,182 @@
+let currentYear = new Date().getFullYear();
+let currentMonth = new Date().getMonth();
+let selectedDate = null;
+
+function renderCalendar() {
+    const calendar = document.getElementById('calendar');
+    calendar.innerHTML = '';
+    const entries = JSON.parse(localStorage.getItem('entries') || '{}');
+    const keyPrefix = `${currentYear}-${currentMonth + 1}`;
+
+    for (let i = 1; i <= new Date(currentYear, currentMonth + 1, 0).getDate(); i++) {
+        const dateKey = `${keyPrefix}-${i}`;
+        const entry = entries[dateKey] || {};
+        const cell = document.createElement('div');
+        cell.className = 'calendar-cell';
+        cell.innerHTML = `<div class="day-number">${i}</div>${entry.stamp ? `<div>${entry.stamp}</div>` : ''}`;
+        cell.onclick = () => {
+            selectedDate = dateKey;
+            loadForm(dateKey);
+            openModal(dateKey);
+        };
+        calendar.appendChild(cell);
+    }
+    document.getElementById('monthLabel').textContent = `${currentYear}年 ${currentMonth + 1}月`;
+}
+
+function renderBookmarks(filter = 'all') {
+    const list = document.getElementById('bookmark-list');
+    if (!list) return;
+    list.innerHTML = '';
+    const entries = JSON.parse(localStorage.getItem('entries') || '{}');
+    const groups = { '💘': [], '😭': [], '💧': [], '😲': [], '😴': [] };
+    Object.entries(entries).forEach(([dateKey, entry]) => {
+        if (filter === '読了' && entry.status !== '読了') return;
+        if (filter === '未読' && entry.status !== '未読') return;
+        if (filter === 'favorite' && !entry.favorite) return;
+        if (['💘','😭','💧','😲','😴'].includes(filter) && entry.stamp !== filter) return;
+        const stamp = entry.stamp || '💘';
+        if (groups[stamp]) groups[stamp].push({dateKey, entry});
+    });
+    Object.entries(groups).forEach(([stamp,cards])=>{
+        if(cards.length>0){
+            const heading=document.createElement('h3');
+            heading.textContent=`${stamp} の本`;
+            list.appendChild(heading);
+            cards.forEach(({dateKey,entry})=>{
+                const card=document.createElement('div');
+                card.className='bookmark-card';
+                if(entry.stamp==='💘') card.classList.add('heart');
+                if(entry.stamp==='😭') card.classList.add('cry');
+                if(entry.stamp==='💧') card.classList.add('tears');
+                if(entry.stamp==='😲') card.classList.add('surprise');
+                if(entry.stamp==='😴') card.classList.add('sleepy');
+                card.innerHTML=`<h4>${entry.title || '(未記入)'} ${entry.favorite?'⭐':''}</h4>
+<p><strong>著者:</strong> ${entry.author || '-'}</p>
+<p><strong>感想:</strong> ${entry.impression || '-'}</p>
+<p><strong>お気に入りの一文:</strong> ${entry.quote || '-'}</p>
+<p><strong>ステータス:</strong> ${entry.status || '未読'}</p>`;
+                card.onclick=()=>{selectedDate=dateKey;loadForm(dateKey);openModal(dateKey);};
+                list.appendChild(card);
+            });
+        }
+    });
+}
+
+document.querySelectorAll('.filter-buttons button').forEach(button=>{
+    button.onclick=()=>{ renderBookmarks(button.getAttribute('data-filter')); };
+});
+
+function loadForm(dateKey){
+    const entries=JSON.parse(localStorage.getItem('entries')||'{}');
+    const entry=entries[dateKey]||{};
+    document.getElementById('calendar-edit-title').value=entry.title||'';
+    document.getElementById('calendar-edit-author').value=entry.author||'';
+    document.getElementById('calendar-edit-impression').value=entry.impression||'';
+    document.getElementById('calendar-edit-quote').value=entry.quote||'';
+    document.getElementById('favorite-check').checked=!!entry.favorite;
+    document.querySelectorAll('#calendar-edit-stamps .stamp').forEach(stamp=>{
+        stamp.classList.toggle('selected', stamp.textContent===entry.stamp);
+    });
+    if(entry.status){
+        document.querySelectorAll('input[name="status"]').forEach(r=>{ r.checked = (r.value===entry.status); });
+    }
+}
+
+function openModal(){
+    const modal=document.getElementById('edit-modal');
+    modal.style.display='flex';
+    const content=modal.querySelector('.modal-content');
+    content.style.animation='modalFadeIn 0.3s forwards';
+}
+function closeModal(){
+    const modal=document.getElementById('edit-modal');
+    const content=modal.querySelector('.modal-content');
+    content.style.animation='modalFadeOut 0.3s forwards';
+    setTimeout(()=>{ modal.style.display='none'; },300);
+}
+
+document.getElementById('calendar-edit-save').onclick=()=>{
+    if(!selectedDate) return;
+    const entries=JSON.parse(localStorage.getItem('entries')||'{}');
+    entries[selectedDate]={
+        title:document.getElementById('calendar-edit-title').value,
+        author:document.getElementById('calendar-edit-author').value,
+        impression:document.getElementById('calendar-edit-impression').value,
+        quote:document.getElementById('calendar-edit-quote').value,
+        stamp:document.querySelector('#calendar-edit-stamps .stamp.selected')?.textContent||'',
+        status:document.querySelector('input[name="status"]:checked')?.value||'未読',
+        favorite:document.getElementById('favorite-check').checked
+    };
+    localStorage.setItem('entries',JSON.stringify(entries));
+    alert('保存しました！');
+    closeModal();
+    renderCalendar();
+    renderBookmarks();
+};
+
+document.getElementById('calendar-edit-delete').onclick=()=>{
+    if(!selectedDate) return;
+    const entries=JSON.parse(localStorage.getItem('entries')||'{}');
+    delete entries[selectedDate];
+    localStorage.setItem('entries',JSON.stringify(entries));
+    alert('削除しました');
+    closeModal();
+    renderCalendar();
+    renderBookmarks();
+};
+
+document.getElementById('calendar-edit-close').onclick=closeModal;
+document.getElementById('edit-modal').addEventListener('click',e=>{ if(e.target.id==='edit-modal') closeModal(); });
+document.querySelectorAll('#calendar-edit-stamps .stamp').forEach(stamp=>{ stamp.onclick=()=>{document.querySelectorAll('#calendar-edit-stamps .stamp').forEach(s=>s.classList.remove('selected')); stamp.classList.add('selected');};});
+
+document.getElementById('prevMonth').onclick=()=>{ currentMonth--; if(currentMonth<0){currentMonth=11;currentYear--;} renderCalendar(); };
+document.getElementById('nextMonth').onclick=()=>{ currentMonth++; if(currentMonth>11){currentMonth=0;currentYear++;} renderCalendar(); };
+
+function renderChart(){
+    const canvas=document.getElementById('stampChart');
+    if(!canvas) return;
+    const entries=JSON.parse(localStorage.getItem('entries')||'{}');
+    const counts={'💘':0,'😭':0,'💧':0,'😲':0,'😴':0};
+    Object.values(entries).forEach(e=>{ if(e.stamp && counts[e.stamp]!==undefined) counts[e.stamp]++; });
+    const ctx=canvas.getContext('2d');
+    new Chart(ctx,{type:'bar',data:{labels:Object.keys(counts),datasets:[{label:'スタンプ使用数',data:Object.values(counts),backgroundColor:['#e76f51','#f4a261','#2a9d8f','#457b9d','#b5838d']}]} ,options:{responsive:true,plugins:{legend:{display:false}},scales:{y:{beginAtZero:true}}});
+}
+
+document.querySelectorAll('.nav a').forEach(link=>{
+    link.onclick=(e)=>{ e.preventDefault(); const target=link.getAttribute('data-target'); document.querySelectorAll('main > section').forEach(s=>s.style.display='none'); document.querySelector('.'+target).style.display='block'; if(target==='bookmark-page') renderBookmarks(); if(target==='mypage-page') renderChart(); };
+});
+
+document.addEventListener('DOMContentLoaded',()=>{ renderCalendar(); renderBookmarks(); });
+
+// --- Book recommendation based on impression text ---
+async function fetchBookByKeyword(keyword){
+    const res=await fetch(`https://www.googleapis.com/books/v1/volumes?q=${encodeURIComponent(keyword)}&maxResults=5`);
+    const data=await res.json();
+    if(data.items && data.items.length>0){
+        const chosen=data.items[Math.floor(Math.random()*data.items.length)].volumeInfo;
+        return { title:chosen.title, authors:(chosen.authors||['不明']).join(', '), description:chosen.description||'説明なし', thumbnail:chosen.imageLinks?.thumbnail||'', infoLink:chosen.infoLink };
+    }
+    throw new Error('本が見つかりません');
+}
+function displayBookCard(book){
+    const html=`<div class="recommend-card"><h3>${book.title}</h3><p><strong>著者:</strong> ${book.authors}</p><p><strong>あらすじ:</strong> ${book.description}</p>${book.thumbnail?`<img src="${book.thumbnail}" alt="表紙">`:''}<br><a href="${book.infoLink}" target="_blank">📖 詳しく読む</a></div>`;
+    document.getElementById('book-card').innerHTML=html;
+}
+
+document.getElementById('analyze-btn').addEventListener('click',async()=>{
+    const text=document.getElementById('impression-text').value;
+    let keyword='小説';
+    if(/泣|悲|涙/.test(text)) keyword='感動 小説';
+    else if(/笑|面白|楽しい/.test(text)) keyword='コメディ 小説';
+    else if(/恋|ラブ|ときめき/.test(text)) keyword='恋愛 小説';
+    else if(/謎|ミステリ|推理/.test(text)) keyword='ミステリー 小説';
+    else if(/癒|ほっこり|リラックス/.test(text)) keyword='癒し 小説';
+    try{
+        const book=await fetchBookByKeyword(keyword);
+        displayBookCard(book);
+    }catch(err){
+        alert('おすすめ本を取得できませんでした');
+        console.error(err);
+    }
+});

--- a/reading_calendar/style.css
+++ b/reading_calendar/style.css
@@ -130,5 +130,5 @@ button[data-filter="all"]{background:#264653;color:#fff;}
 .bookmark-card.surprise{background:#fff3e0;}
 .bookmark-card.sleepy{background:#f3e5f5;}
 
-.nav{ display:flex; justify-content:space-around; padding:1rem 0; background:#fafafa; border-top:1px solid #ccc; position:fixed; bottom:0; width:100%; }
+.nav{ display:flex; justify-content:space-around; padding:1rem 0; background:#fafafa; border-top:1px solid #ccc; position:fixed; bottom:50px; width:100%; }
 .nav a{text-decoration:none;color:#264653;font-weight:bold;}

--- a/reading_calendar/style.css
+++ b/reading_calendar/style.css
@@ -130,5 +130,22 @@ button[data-filter="all"]{background:#264653;color:#fff;}
 .bookmark-card.surprise{background:#fff3e0;}
 .bookmark-card.sleepy{background:#f3e5f5;}
 
+.recommend-card{
+    background:#fffdf6;
+    border:1px solid #ccc;
+    border-radius:8px;
+    padding:1rem;
+    margin-top:1rem;
+}
+
+#mood-buttons button{
+    margin:0.2rem;
+    padding:0.4rem 0.8rem;
+    border-radius:6px;
+    border:1px solid #ccc;
+    cursor:pointer;
+}
+
+#roulette-status{ margin-top:0.5rem; }
 .nav{ display:flex; justify-content:space-around; padding:1rem 0; background:#fafafa; border-top:1px solid #ccc; position:fixed; bottom:50px; width:100%; }
 .nav a{text-decoration:none;color:#264653;font-weight:bold;}

--- a/reading_calendar/style.css
+++ b/reading_calendar/style.css
@@ -1,0 +1,134 @@
+body {
+    font-family: 'Yu Mincho', serif;
+    background: #f5f2e9;
+    margin: 0;
+    padding: 0;
+}
+
+header {
+    text-align: center;
+    padding: 1rem;
+    background-color: #fafafa;
+    border-bottom: 1px solid #ccc;
+}
+
+.month-switch {
+    display: flex;
+    justify-content: center;
+    gap: 1rem;
+    margin-top: 0.5rem;
+}
+
+main>section {
+    padding: 1rem;
+}
+
+.calendar-grid {
+    display: grid;
+    grid-template-columns: repeat(7, 1fr);
+    gap: 5px;
+    padding: 1rem;
+    max-width: 700px;
+    margin: 0 auto;
+}
+
+.calendar-cell {
+    border: 1px solid #ccc;
+    border-radius: 6px;
+    background: #fff;
+    height: 80px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    position: relative;
+    cursor: pointer;
+}
+
+.day-number {
+    position: absolute;
+    top: 4px;
+    left: 6px;
+    font-size: 0.8rem;
+    color: #999;
+}
+
+.modal {
+    display: none;
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100vw;
+    height: 100vh;
+    background: rgba(0, 0, 0, 0.5);
+    justify-content: center;
+    align-items: center;
+    z-index: 999;
+}
+
+@keyframes modalFadeIn {
+    from { opacity: 0; transform: scale(0.9); }
+    to { opacity: 1; transform: scale(1); }
+}
+@keyframes modalFadeOut {
+    from { opacity: 1; transform: scale(1); }
+    to { opacity: 0; transform: scale(0.9); }
+}
+
+.modal-content {
+    background: #fffdf6;
+    border: 2px dashed #AD8D73;
+    border-radius: 12px;
+    padding: 2rem;
+    width: 90%;
+    max-width: 500px;
+    position: relative;
+    opacity: 0;
+    transform: scale(0.9);
+    transition: opacity 0.3s, transform 0.3s;
+}
+.modal-content h2 { text-align: center; margin-bottom: 1rem; }
+.modal-content input,
+.modal-content textarea {
+    width: 100%;
+    margin-bottom: 1rem;
+    padding: 0.5rem;
+    border-radius: 4px;
+    border: 1px solid #ccc;
+    box-sizing: border-box;
+}
+
+.stamp { cursor: pointer; margin: 5px; display: inline-block; font-size: 1.5rem; }
+.stamp.selected { border: 2px solid #264653; border-radius: 50%; padding: 2px; }
+
+.filter-buttons { text-align: center; margin-bottom: 1rem; }
+.filter-buttons button { margin: 0.2rem; padding: 0.5rem 0.8rem; border-radius: 20px; border:none; cursor:pointer; transition: background 0.3s, transform 0.2s; }
+.filter-buttons button:hover { transform: scale(1.05); }
+
+button[data-filter="読了"]{background:#2a9d8f;color:#fff;}
+button[data-filter="未読"]{background:#e76f51;color:#fff;}
+button[data-filter="favorite"]{background:#f4a261;color:#fff;}
+button[data-filter="💘"]{background:#ffb3c1;color:#fff;}
+button[data-filter="😭"]{background:#80deea;color:#fff;}
+button[data-filter="💧"]{background:#90caf9;color:#fff;}
+button[data-filter="😲"]{background:#ffcc80;color:#fff;}
+button[data-filter="😴"]{background:#ce93d8;color:#fff;}
+button[data-filter="all"]{background:#264653;color:#fff;}
+
+.form-buttons{text-align:center;}
+.submit-btn, .delete-btn, .close-btn{ padding:0.5rem 1rem; border-radius:6px; border:none; cursor:pointer; margin:0.5rem; }
+.submit-btn{background:#264653;color:white;}
+.delete-btn{background:#b83b5e;color:white;}
+.close-btn{background:transparent;color:#333; position:absolute; top:10px; right:10px; font-size:1.5rem; border:none;}
+
+#bookmark-list{ max-width:700px; margin:0 auto; margin-top:2rem; }
+.bookmark-card{ background:#fff; border:1px solid #ccc; border-radius:8px; padding:1rem; margin-bottom:1rem; cursor:pointer; transition:transform 0.3s, box-shadow 0.3s; }
+.bookmark-card:hover{ transform:translateY(-5px); box-shadow:0 4px 10px rgba(0,0,0,0.1); }
+.bookmark-card.heart{background:#ffe5ec;}
+.bookmark-card.cry{background:#e0f7fa;}
+.bookmark-card.tears{background:#e3f2fd;}
+.bookmark-card.surprise{background:#fff3e0;}
+.bookmark-card.sleepy{background:#f3e5f5;}
+
+.nav{ display:flex; justify-content:space-around; padding:1rem 0; background:#fafafa; border-top:1px solid #ccc; position:fixed; bottom:0; width:100%; }
+.nav a{text-decoration:none;color:#264653;font-weight:bold;}


### PR DESCRIPTION
## Summary
- add a new `reading_calendar` sample with HTML/CSS/JS
- calendar records daily entries and recommends books based on mood
- update README with demo note

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684a68771c30833086302dc01ab9bca2